### PR TITLE
Return correct PrimalStatus when solve terminates before optimality

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -830,7 +830,7 @@ function MOI.get(model::Optimizer, ::MOI.RawStatusString)
 end
 
 function MOI.get(model::Optimizer, ::MOI.ResultCount)
-    return Cbc_bestSolution(model.inner) != C_NULL ? 1 : 0
+    return Cbc_numberSavedSolutions(model.inner) > 0 ? 1 : 0
 end
 
 function MOI.get(model::Optimizer, ::MOI.TerminationStatus)
@@ -865,11 +865,10 @@ function MOI.get(model::Optimizer, ::MOI.TerminationStatus)
     end
 end
 
-# TODO(odow): handle solutions that may exist when limit reached.
 function MOI.get(model::Optimizer, attr::MOI.PrimalStatus)
     if attr.N != 1
         return MOI.NO_SOLUTION
-    elseif MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
+    elseif MOI.get(model, MOI.ResultCount()) == 1
         return MOI.FEASIBLE_POINT
     else
         return MOI.NO_SOLUTION

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -104,13 +104,26 @@ end
         )
     )
     model = Cbc.Optimizer(
-        maxNodes = 0, presolve = "off", cuts = "off", heur = "off", logLevel = 0
+        maxSol = 1, presolve = "off", cuts = "off", heur = "off", logLevel = 0
     )
     MOI.copy_to(model, knapsack_model)
     MOI.optimize!(model)
-    @test MOI.get(model, MOI.TerminationStatus()) == MOI.NODE_LIMIT
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.SOLUTION_LIMIT
+    @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
     MOI.empty!(model)
     MOI.copy_to(model, knapsack_model)
     MOI.optimize!(model)
-    @test MOI.get(model, MOI.TerminationStatus()) == MOI.NODE_LIMIT
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.SOLUTION_LIMIT
+    @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+end
+
+@testset "Test PrimalStatus" begin
+    model = MOI.Utilities.Model{Float64}()
+    x = MOI.add_variable(model)
+    MOI.add_constraint(model, x, MOI.GreaterThan(1.0))
+    MOI.add_constraint(model, x, MOI.LessThan(0.0))
+    cbc = Cbc.Optimizer()
+    MOI.copy_to(cbc, model)
+    MOI.optimize!(cbc)
+    MOI.get(cbc, MOI.PrimalStatus()) == MOI.NO_SOLUTION
 end


### PR DESCRIPTION
Closes #142 

I couldn't find anything suggesting that Cbc will return an `INFEASIBLE_POINT`, so we just assume that if `Cbc_numberSavedSolutions(model) == 1`, then there is a feasible solution. 