### PR TITLE
Fix performance issue

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -734,6 +734,8 @@ function MOI.optimize!(model::Optimizer)
         Cbc_setMIPStartI(model, length(columns), columns, values)
     end
     t = time()
+    model.variable_primal = nothing
+    model.constraint_primal = nothing
     model.termination_status = Cbc_solve(model)
     model.has_solution = _result_count(model)
     model.solve_time = time() - t


### PR DESCRIPTION
Closes #172 
Closes #173 

## Before

```Julia
julia> bench();
Optimal - objective value 4.50015e+08
Optimal objective 450015000 - 0 iterations time 0.002
  4.113598 seconds (60.00 k allocations: 2.976 MiB)
```

## After

```Julia
julia> bench();
Optimal - objective value 4.50015e+08
Optimal objective 450015000 - 0 iterations time 0.002
  0.000598 seconds (4 allocations: 234.547 KiB)
```

## Script

```Julia
using Cbc
const MOI = Cbc.MOI

function bench(N = 30_000)
    cbc = Cbc.Optimizer()
    model = MOI.Utilities.CachingOptimizer(MOI.Utilities.Model{Float64}(), cbc)
    x = MOI.add_variables(model, N);
    MOI.add_constraints(model, x, MOI.GreaterThan.(1.0:N));
    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE);
    f = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, x), 0.0);
    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f);
    MOI.optimize!(model)
    @time MOI.get.(model, MOI.VariablePrimal(), x)
end
bench()
```