### PR TITLE
Bump minimum version of MOI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Cbc"
 uuid = "9961bab8-2fa3-5c5a-9d89-47fab24efd76"
 repo = "https://github.com/jump-dev/Cbc.jl.git"
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
@@ -15,7 +15,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 BinaryProvider = "0.5.9"
 CEnum = "0.3, 0.4"
 Cbc_jll = "=2.10.5, ~200.1000.500"
-MathOptInterface = "0.10"
+MathOptInterface = "0.10.6"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
This shouldn't have been 0.10

I also want to check if the new Cbc_jll works on all platforms.