### PR TITLE
Update to Cbc_jll dep to fix Clp_jll compatibility with MUMPS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Cbc"
 uuid = "9961bab8-2fa3-5c5a-9d89-47fab24efd76"
 repo = "https://github.com/jump-dev/Cbc.jl.git"
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 Cbc_jll = "38041ee0-ae04-5750-a4d2-bb4d0d83d27d"
@@ -9,7 +9,7 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-Cbc_jll = "=2.10.5, ~200.1000.500"
+Cbc_jll = "=2.10.5, ~200.1000.501"
 MathOptInterface = "1"
 julia = "1.6"
 


### PR DESCRIPTION
Matches https://github.com/jump-dev/Clp.jl/pull/133, we experienced a similar downgrade of Cbc_jll and are running into `libdmumps.so: cannot open shared object file: No such file or directory`

Closes #196 