### PR TITLE
Add aarch64-apple to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
           - version: '1.6'
             os: ubuntu-latest
             arch: x86
+          # Test against Apple M-series
+          - version: '1'
+            os: macos-14
+            arch: aarch64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
Closes #193 

- [ ] Requires https://github.com/jump-dev/Clp.jl/pull/149